### PR TITLE
bug: version command should work without cluster access

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,6 +16,7 @@ jobs:
         - TestSingleNodeInstallationRockyLinux8
         - TestSingleNodeInstallationDebian12
         - TestSingleNodeInstallationCentos8Stream
+        - TestVersion
     steps:
     - name: Move Docker aside
       run: |

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/replicatedhq/helmvm/e2e/cluster"
+)
+
+func TestVersion(t *testing.T) {
+	t.Parallel()
+	tc := cluster.NewTestCluster(&cluster.Input{
+		T:             t,
+		Nodes:         1,
+		Image:         "ubuntu/jammy",
+		SSHPublicKey:  "../output/tmp/id_rsa.pub",
+		SSHPrivateKey: "../output/tmp/id_rsa",
+		HelmVMPath:    "../output/bin/helmvm",
+	})
+	defer tc.Destroy()
+	t.Log("validating helmvm version in node 0")
+	line := []string{"helmvm", "version"}
+	stdout, stderr, err := RunCommandOnNode(t, tc, 0, line)
+	if err != nil {
+		t.Fatalf("fail to install ssh on node %s: %v", tc.Nodes[0], err)
+	}
+	var failed bool
+	output := fmt.Sprintf("%s\n%s", stdout, stderr)
+	expected := []string{"Installer", "Kubernetes", "OpenEBS", "AdminConsole"}
+	for _, component := range expected {
+		if strings.Contains(output, "Installer") {
+			continue
+		}
+		t.Errorf("missing %q version in 'version' output", component)
+		failed = true
+	}
+	if failed {
+		t.Log(output)
+	}
+}

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -29,7 +29,7 @@ func TestVersion(t *testing.T) {
 	output := fmt.Sprintf("%s\n%s", stdout, stderr)
 	expected := []string{"Installer", "Kubernetes", "OpenEBS", "AdminConsole"}
 	for _, component := range expected {
-		if strings.Contains(output, "Installer") {
+		if strings.Contains(output, component) {
 			continue
 		}
 		t.Errorf("missing %q version in 'version' output", component)

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -14,7 +14,6 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/replicatedhq/helmvm/pkg/addons/adminconsole/charts"
 )
@@ -167,7 +166,7 @@ func (a *AdminConsole) installedRelease(ctx context.Context) (*release.Release, 
 	return releases[0], nil
 }
 
-func New(ns string, prompt bool, kcli client.Client, log action.DebugLog) (*AdminConsole, error) {
+func New(ns string, prompt bool, log action.DebugLog) (*AdminConsole, error) {
 	env := cli.New()
 	env.SetNamespace(ns)
 	config := &action.Configuration{}
@@ -179,6 +178,6 @@ func New(ns string, prompt bool, kcli client.Client, log action.DebugLog) (*Admi
 		config:        config,
 		logger:        log,
 		prompt:        prompt,
-		customization: AdminConsoleCustomization{kcli},
+		customization: AdminConsoleCustomization{},
 	}, nil
 }

--- a/pkg/addons/adminconsole/customize.go
+++ b/pkg/addons/adminconsole/customize.go
@@ -16,14 +16,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // AdminConsoleCustomization is a struct that contains the actions to create and update
 // the admin console customization found inside the binary. This is necessary for
 // backwards compatibility with older versions of helmvm.
-type AdminConsoleCustomization struct {
-	kubeclient client.Client
-}
+type AdminConsoleCustomization struct{}
 
 // extractCustomization will extract the customization from the binary if it exists.
 // If it does not exist, it will return nil, nil. The customization is expected to
@@ -82,6 +83,19 @@ func (a *AdminConsoleCustomization) processSection(section *elf.Section) ([]byte
 	}
 }
 
+// kubeClient returns a new kubernetes client.
+func (a *AdminConsoleCustomization) kubeClient() (client.Client, error) {
+	k8slogger := zap.New(func(o *zap.Options) {
+		o.DestWriter = io.Discard
+	})
+	log.SetLogger(k8slogger)
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("unable to process kubernetes config: %w", err)
+	}
+	return client.New(cfg, client.Options{})
+}
+
 // apply will attempt to read the helmvm binary and extract the kotsadm portal
 // customization from it. If it finds one, it will apply it to the cluster.
 func (a *AdminConsoleCustomization) apply(ctx context.Context) error {
@@ -98,10 +112,14 @@ func (a *AdminConsoleCustomization) apply(ctx context.Context) error {
 		logrus.Infof("No admin console customization found")
 		return nil
 	}
+	kubeclient, err := a.kubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kubernetes client: %w", err)
+	}
 	logrus.Infof("Admin console customization found")
 	nsn := client.ObjectKey{Namespace: "helmvm", Name: "kotsadm-application-metadata"}
 	var cm corev1.ConfigMap
-	if err := a.kubeclient.Get(ctx, nsn, &cm); err != nil {
+	if err := kubeclient.Get(ctx, nsn, &cm); err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("unable to get kotsadm-application configmap: %w", err)
 		}
@@ -115,14 +133,14 @@ func (a *AdminConsoleCustomization) apply(ctx context.Context) error {
 				"application.yaml": string(cust),
 			},
 		}
-		if err := a.kubeclient.Create(ctx, &cm); err != nil {
+		if err := kubeclient.Create(ctx, &cm); err != nil {
 			return fmt.Errorf("unable to create kotsadm-application configmap: %w", err)
 		}
 		return nil
 	}
 	logrus.Infof("Updating admin console customization config map")
 	cm.Data["application.yaml"] = string(cust)
-	if err := a.kubeclient.Update(ctx, &cm); err != nil {
+	if err := kubeclient.Update(ctx, &cm); err != nil {
 		return fmt.Errorf("unable to update kotsadm-application configmap: %w", err)
 	}
 	return nil


### PR DESCRIPTION
`helmvm version` should work even without having access to a cluster. prior to this commit version command required a kubernetes client to work properly, this is not a requirement.