### PR TITLE
chore: fixed helmvm builder docker build process

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -54,4 +54,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:$TAG_NAME
+          tags: ghcr.io/${{ github.repository }}:${{ env.TAG_NAME }}


### PR DESCRIPTION
tag_name is not properly processed, we need env.tag_name.