### PR TITLE
chore: disable builder image generation

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -41,17 +41,3 @@ jobs:
           prerelease: false
           files: |
             *.tgz
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and Publish HelmVM Builder Server image.
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/${{ github.repository }}:${{ env.TAG_NAME }}


### PR DESCRIPTION
this is not mandatory and we are not sure we want to keep developing this. as the push is failing (as far as i could read due to org level permissioning) this commit removes the helmvm builder image build and publish job from the github action.

we can enable it again in the future if we decide this is a goal we want to pursuit.