### PR TITLE
feat: allow disabling add-ons

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,6 +17,8 @@ jobs:
         - TestSingleNodeInstallationCentos8Stream
         - TestVersion
         - TestMultiNodeInteractiveInstallation
+        - TestInstallWithDisabledAddons
+        - TestEmbedAddonsOnly
     steps:
     - name: Move Docker aside
       run: |

--- a/cmd/helmvm/upgrade.go
+++ b/cmd/helmvm/upgrade.go
@@ -51,6 +51,10 @@ var upgradeCommand = &cli.Command{
 			Usage: "Do not prompt user when it is not necessary",
 			Value: false,
 		},
+		&cli.StringSliceFlag{
+			Name:  "disable-addon",
+			Usage: "Disable addon during upgrade",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		if err := canRunUpgrade(c); err != nil {
@@ -81,9 +85,14 @@ var upgradeCommand = &cli.Command{
 		}
 		os.Setenv("KUBECONFIG", kcfg)
 		logrus.Infof("Upgrading addons")
-		if applier, err := addons.NewApplier(c.Bool("no-prompt"), true); err != nil {
-			return fmt.Errorf("unable to create applier: %w", err)
-		} else if err := applier.Apply(c.Context); err != nil {
+		opts := []addons.Option{}
+		if c.Bool("no-prompt") {
+			opts = append(opts, addons.WithoutPrompt())
+		}
+		for _, addon := range c.StringSlice("disable-addon") {
+			opts = append(opts, addons.WithoutAddon(addon))
+		}
+		if err := addons.NewApplier(opts...).Apply(c.Context); err != nil {
 			return fmt.Errorf("unable to apply addons: %w", err)
 		}
 		logrus.Infof("Upgrade complete")

--- a/cmd/helmvm/version.go
+++ b/cmd/helmvm/version.go
@@ -17,11 +17,8 @@ var versionCommand = &cli.Command{
 	Name:  "version",
 	Usage: fmt.Sprintf("Shows the %s installer version", defaults.BinaryName()),
 	Action: func(c *cli.Context) error {
-		applier, err := addons.NewApplier(true, false)
-		if err != nil {
-			return fmt.Errorf("unable to create applier: %w", err)
-		}
-		versions, err := applier.Versions()
+		opts := []addons.Option{addons.Quiet(), addons.WithoutPrompt()}
+		versions, err := addons.NewApplier(opts...).Versions()
 		if err != nil {
 			return fmt.Errorf("unable to get versions: %w", err)
 		}

--- a/e2e/embed_test.go
+++ b/e2e/embed_test.go
@@ -33,3 +33,31 @@ func TestEmbedAndInstall(t *testing.T) {
 		t.Fatalf("fail to create deployment with pvc: %v", err)
 	}
 }
+
+func TestEmbedAddonsOnly(t *testing.T) {
+	t.Parallel()
+	tc := cluster.NewTestCluster(&cluster.Input{
+		T:             t,
+		Nodes:         1,
+		Image:         "ubuntu/jammy",
+		SSHPublicKey:  "../output/tmp/id_rsa.pub",
+		SSHPrivateKey: "../output/tmp/id_rsa",
+		HelmVMPath:    "../output/bin/helmvm",
+	})
+	defer tc.Destroy()
+	t.Log("installing ssh in node 0")
+	line := []string{"apt", "install", "openssh-server", "-y"}
+	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+		t.Fatalf("fail to install ssh on node %s: %v", tc.Nodes[0], err)
+	}
+	t.Log("installing helmvm on node 0")
+	line = []string{"single-node-install.sh"}
+	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+		t.Fatalf("fail to install helmvm on node %s: %v", tc.Nodes[0], err)
+	}
+	t.Log("testing --addons-only on node 0")
+	line = []string{"addons-only.sh"}
+	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+		t.Fatalf("fail to install embedded ssh in node 0: %v", err)
+	}
+}

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -229,3 +229,26 @@ func TestMultiNodeInteractiveInstallation(t *testing.T) {
 		t.Fatalf("nodes not reporting ready: %v", err)
 	}
 }
+
+func TestInstallWithDisabledAddons(t *testing.T) {
+	t.Parallel()
+	tc := cluster.NewTestCluster(&cluster.Input{
+		T:             t,
+		Nodes:         1,
+		Image:         "ubuntu/jammy",
+		SSHPublicKey:  "../output/tmp/id_rsa.pub",
+		SSHPrivateKey: "../output/tmp/id_rsa",
+		HelmVMPath:    "../output/bin/helmvm",
+	})
+	defer tc.Destroy()
+	t.Log("installing ssh in node 0")
+	line := []string{"apt", "install", "openssh-server", "-y"}
+	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+		t.Fatalf("fail to install ssh on node %s: %v", tc.Nodes[0], err)
+	}
+	t.Log("installling with disabled addons on node 0")
+	line = []string{"install-with-disabled-addons.sh"}
+	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+		t.Fatalf("fail to install embedded ssh in node 0: %v", err)
+	}
+}

--- a/e2e/scripts/addons-only.sh
+++ b/e2e/scripts/addons-only.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# This script is used to test the embed capability of helmvm. It will pull the memcached helm chart and
+# embed it into the binary, issuing then a single node install. This script waits for the memcached pod
+# to be ready.
+set -euo pipefail
+
+wait_for_healthy_node() {
+    ready=$(kubectl get nodes | grep -v NotReady | grep -c Ready || true)
+    counter=0
+    while [ "$ready" -lt "1" ]; do
+        if [ "$counter" -gt 36 ]; then
+            return 1
+        fi
+        sleep 5
+        counter=$((counter+1))
+        echo "Waiting for node to be ready"
+        ready=$(kubectl get nodes | grep -v NotReady | grep -c Ready || true)
+        kubectl get nodes || true
+    done
+    return 0
+}
+
+install_helm() {
+    apt update -y
+    if ! apt install -y curl ; then
+        return 1
+    fi
+    if ! curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 ; then
+        return 1
+    fi
+    chmod 700 get_helm.sh
+    if ! ./get_helm.sh ; then
+        return 1
+    fi
+    return 0
+}
+
+pull_helm_chart() {
+    mkdir chart
+    if ! helm pull oci://registry-1.docker.io/bitnamicharts/memcached --destination chart; then
+        return 1
+    fi
+    return 0
+}
+
+embed_helm_chart() {
+    fpath=$(ls -d chart/*)
+    if ! helmvm embed --chart "$fpath" --output helmvm; then
+        echo "Failed embed helm chart"
+        exit 1
+    fi
+    mv helmvm /usr/local/bin
+    return 0
+}
+
+wait_for_memcached_pods() {
+    ready=$(kubectl get pods -n helmvm | grep -v NotReady | grep Ready | grep -c memcached || true)
+    counter=0
+    while [ "$ready" -lt "1" ]; do
+        if [ "$counter" -gt 36 ]; then
+            return 1
+        fi
+        sleep 5
+        counter=$((counter+1))
+        echo "Waiting for memcached pods to be ready"
+        ready=$(kubectl get pods -n helmvm | grep  Running | grep -c memcached || true)
+        kubectl get pods -n helmvm 2>&1 || true
+        echo "$ready"
+    done
+    return 0
+}
+
+main() {
+    if ! install_helm ; then
+        echo "Failed to install helm"
+        exit 1
+    fi
+    if ! pull_helm_chart ; then
+        echo "Failed to pull helm chart"
+        exit 1
+    fi
+    if ! embed_helm_chart ; then
+        echo "Failed to embed helm chart"
+        exit 1
+    fi
+    if ! helmvm install --no-prompt --addons-only 2>&1 | tee /tmp/log ; then
+        echo "Failed to install addons"
+        exit 1
+    fi
+    if ! grep -q "You can now access your cluster" /tmp/log; then
+        echo "Failed to install helmvm"
+        exit 1
+    fi
+    echo "waiting for nodes" >> /tmp/log
+    if ! wait_for_healthy_node; then
+        echo "Nodes not reporting healthy"
+        exit 1
+    fi
+    echo "waiting for memcached " >> /tmp/log
+    if ! wait_for_memcached_pods; then
+        echo "Memcached pods not reporting healthy"
+        exit 1
+    fi
+}
+
+export KUBECONFIG=/root/.helmvm/etc/kubeconfig
+export PATH="$PATH:/root/.helmvm/bin"
+main

--- a/e2e/scripts/addons-only.sh
+++ b/e2e/scripts/addons-only.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 wait_for_healthy_node() {
     ready=$(kubectl get nodes | grep -v NotReady | grep -c Ready || true)
     counter=0
-    while [ "$ready" -lt "1" ]; do
+    while [ -z "$ready" ] || [ "$ready" -lt "1" ]; do
         if [ "$counter" -gt 36 ]; then
             return 1
         fi
@@ -46,8 +46,7 @@ pull_helm_chart() {
 embed_helm_chart() {
     fpath=$(ls -d chart/*)
     if ! helmvm embed --chart "$fpath" --output helmvm; then
-        echo "Failed embed helm chart"
-        exit 1
+        return 1
     fi
     mv helmvm /usr/local/bin
     return 0
@@ -56,7 +55,7 @@ embed_helm_chart() {
 wait_for_memcached_pods() {
     ready=$(kubectl get pods -n helmvm | grep -v NotReady | grep Ready | grep -c memcached || true)
     counter=0
-    while [ "$ready" -lt "1" ]; do
+    while [ -z "$ready" ] || [ "$ready" -lt "1" ]; do
         if [ "$counter" -gt 36 ]; then
             return 1
         fi

--- a/e2e/scripts/install-with-disabled-addons.sh
+++ b/e2e/scripts/install-with-disabled-addons.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+wait_for_healthy_node() {
+    ready=$(kubectl get nodes | grep -v NotReady | grep -c Ready || true)
+    counter=0
+    while [ "$ready" -lt "1" ]; do
+        if [ "$counter" -gt 36 ]; then
+            return 1
+        fi
+        sleep 5
+        counter=$((counter+1))
+        echo "Waiting for node to be ready"
+        ready=$(kubectl get nodes | grep -v NotReady | grep -c Ready || true)
+        kubectl get nodes || true
+    done
+    return 0
+}
+
+install_helm() {
+    apt update -y
+    if ! apt install -y curl ; then
+        return 1
+    fi
+    if ! curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 ; then
+        return 1
+    fi
+    chmod 700 get_helm.sh
+    if ! ./get_helm.sh ; then
+        return 1
+    fi
+    return 0
+}
+
+pull_helm_chart() {
+    mkdir chart
+    if ! helm pull oci://registry-1.docker.io/bitnamicharts/memcached --destination chart; then
+        return 1
+    fi
+    return 0
+}
+
+embed_helm_chart() {
+    fpath=$(ls -d chart/*)
+    if ! helmvm embed --chart "$fpath" --output helmvm; then
+        echo "Failed embed helm chart"
+        exit 1
+    fi
+    mv helmvm /usr/local/bin
+    return 0
+}
+
+check_empty_helmvm_namespace() {
+    pods=$(kubectl get pods -n helmvm | wc -l)
+    if [ "$pods" -gt 0 ]; then
+        kubectl get pods -n helmvm
+        return 1
+    fi
+}
+
+main() {
+    if ! install_helm ; then
+        echo "Failed to install helm"
+        exit 1
+    fi
+    if ! pull_helm_chart ; then
+        echo "Failed to pull helm chart"
+        exit 1
+    fi
+    if ! embed_helm_chart ; then
+        echo "Failed to embed helm chart"
+        exit 1
+    fi
+    if ! helmvm install --disable-addon openebs --disable-addon adminconsole --disable-addon memcached --no-prompt  2>&1 | tee /tmp/log ; then
+        echo "Failed to install helmvm"
+        exit 1
+    fi
+    if ! grep -q "You can now access your cluster" /tmp/log; then
+        echo "Failed to install helmvm"
+        exit 1
+    fi
+    echo "waiting for nodes" >> /tmp/log
+    if ! wait_for_healthy_node; then
+        echo "Nodes not reporting healthy"
+        exit 1
+    fi
+    echo "check nothing exists on helmvm namespace " >> /tmp/log
+    if ! check_empty_helmvm_namespace; then
+        echo "Pods found on helmvm namespace"
+        exit 1
+    fi
+}
+
+export KUBECONFIG=/root/.helmvm/etc/kubeconfig
+export PATH=$PATH:/root/.helmvm/bin
+main

--- a/e2e/scripts/install-with-disabled-addons.sh
+++ b/e2e/scripts/install-with-disabled-addons.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 wait_for_healthy_node() {
     ready=$(kubectl get nodes | grep -v NotReady | grep -c Ready || true)
     counter=0
-    while [ "$ready" -lt "1" ]; do
+    while [ -z "$ready" ] || [ "$ready" -lt "1" ]; do
         if [ "$counter" -gt 36 ]; then
             return 1
         fi
@@ -43,8 +43,7 @@ pull_helm_chart() {
 embed_helm_chart() {
     fpath=$(ls -d chart/*)
     if ! helmvm embed --chart "$fpath" --output helmvm; then
-        echo "Failed embed helm chart"
-        exit 1
+        return 1
     fi
     mv helmvm /usr/local/bin
     return 0

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -23,19 +23,12 @@ import (
 	"github.com/replicatedhq/helmvm/pkg/progressbar"
 )
 
-type Applier struct {
-	addons map[string]AddOn
-}
-
-// DoNotLog is a helper function to disable logging for addons.
-func DoNotLog(format string, v ...interface{}) {}
-
 // getLogger creates a logger to be used in an addon.
 func getLogger(addon string, verbose bool) action.DebugLog {
-	if !verbose {
-		return DoNotLog
+	if verbose {
+		return logrus.WithField("addon", addon).Infof
 	}
-	return logrus.WithField("addon", addon).Infof
+	return func(string, ...interface{}) {}
 }
 
 // AddOn is the interface that all addons must implement.
@@ -44,13 +37,24 @@ type AddOn interface {
 	Version() (map[string]string, error)
 }
 
+// Applier is an entity that applies (installs and updates) addons in the cluster.
+type Applier struct {
+	disabledAddons map[string]bool
+	prompt         bool
+	verbose        bool
+}
+
 // Apply applies all registered addons to the cluster. Simply calls Apply on
 // each addon.
 func (a *Applier) Apply(ctx context.Context) error {
 	if err := a.waitForKubernetes(ctx); err != nil {
 		return fmt.Errorf("unable to wait for kubernetes: %w", err)
 	}
-	for name, addon := range a.addons {
+	addons, err := a.load()
+	if err != nil {
+		return fmt.Errorf("unable to load addons: %w", err)
+	}
+	for name, addon := range addons {
 		logrus.Infof("Apply addon %s.", name)
 		if err := addon.Apply(ctx); err != nil {
 			return err
@@ -60,10 +64,39 @@ func (a *Applier) Apply(ctx context.Context) error {
 	return nil
 }
 
+// load instantiates all enabled addons.
+func (a *Applier) load() (map[string]AddOn, error) {
+	addons := map[string]AddOn{}
+	if _, disabledAddons := a.disabledAddons["openebs"]; !disabledAddons {
+		obs, err := openebs.New("helmvm", getLogger("openebs", a.verbose))
+		if err != nil {
+			return nil, fmt.Errorf("unable to create admin console addon: %w", err)
+		}
+		addons["openebs"] = obs
+	}
+	if _, disabledAddons := a.disabledAddons["adminconsole"]; !disabledAddons {
+		aconsole, err := adminconsole.New("helmvm", a.prompt, getLogger("adminconsole", a.verbose))
+		if err != nil {
+			return nil, fmt.Errorf("unable to create admin console addon: %w", err)
+		}
+		addons["adminconsole"] = aconsole
+	}
+	custom, err := custom.New("helmvm", getLogger("custom", a.verbose), a.disabledAddons)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create admin console addon: %w", err)
+	}
+	addons["custom"] = custom
+	return addons, nil
+}
+
 // Version returns a map with the version of each addon that will be applied.
 func (a *Applier) Versions() (map[string]string, error) {
+	addons, err := a.load()
+	if err != nil {
+		return nil, fmt.Errorf("unable to load addons: %w", err)
+	}
 	versions := map[string]string{}
-	for name, addon := range a.addons {
+	for name, addon := range addons {
 		version, err := addon.Version()
 		if err != nil {
 			return nil, fmt.Errorf("unable to get version (%s): %w", name, err)
@@ -121,22 +154,14 @@ func (a *Applier) waitForKubernetes(ctx context.Context) error {
 }
 
 // NewApplier creates a new Applier instance with all addons registered.
-func NewApplier(prompt, verbose bool) (*Applier, error) {
-	applier := &Applier{addons: map[string]AddOn{}}
-	obs, err := openebs.New("helmvm", getLogger("openebs", verbose))
-	if err != nil {
-		return nil, fmt.Errorf("unable to create admin console addon: %w", err)
+func NewApplier(opts ...Option) *Applier {
+	applier := &Applier{
+		prompt:         true,
+		verbose:        true,
+		disabledAddons: map[string]bool{},
 	}
-	applier.addons["openebs"] = obs
-	aconsole, err := adminconsole.New("helmvm", prompt, getLogger("adminconsole", verbose))
-	if err != nil {
-		return nil, fmt.Errorf("unable to create admin console addon: %w", err)
+	for _, fn := range opts {
+		fn(applier)
 	}
-	applier.addons["adminconsole"] = aconsole
-	custom, err := custom.New("helmvm", getLogger("custom", verbose))
-	if err != nil {
-		return nil, fmt.Errorf("unable to create admin console addon: %w", err)
-	}
-	applier.addons["custom"] = custom
-	return applier, nil
+	return applier
 }

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -70,7 +70,7 @@ func (a *Applier) load() (map[string]AddOn, error) {
 	if _, disabledAddons := a.disabledAddons["openebs"]; !disabledAddons {
 		obs, err := openebs.New("helmvm", getLogger("openebs", a.verbose))
 		if err != nil {
-			return nil, fmt.Errorf("unable to create admin console addon: %w", err)
+			return nil, fmt.Errorf("unable to create openebs addon: %w", err)
 		}
 		addons["openebs"] = obs
 	}
@@ -83,7 +83,7 @@ func (a *Applier) load() (map[string]AddOn, error) {
 	}
 	custom, err := custom.New("helmvm", getLogger("custom", a.verbose), a.disabledAddons)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create admin console addon: %w", err)
+		return nil, fmt.Errorf("unable to create custom addon: %w", err)
 	}
 	addons["custom"] = custom
 	return addons, nil

--- a/pkg/addons/custom/custom.go
+++ b/pkg/addons/custom/custom.go
@@ -74,7 +74,7 @@ func (c *Custom) applyOne(ctx context.Context, ochart hembed.HelmChart) error {
 		return fmt.Errorf("unable to load chart archive: %w", err)
 	}
 	if c.chartHasBeenDisabled(chart) {
-		c.logger("Skipping disabled chart %s", chart.Name())
+		c.logger("Skipping disabled addon %s", chart.Name())
 		return nil
 	}
 	var values map[string]interface{}

--- a/pkg/addons/custom/custom.go
+++ b/pkg/addons/custom/custom.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"golang.org/x/mod/semver"
 	"helm.sh/helm/v3/pkg/action"
@@ -19,9 +20,10 @@ import (
 )
 
 type Custom struct {
-	config    *action.Configuration
-	logger    action.DebugLog
-	namespace string
+	config         *action.Configuration
+	logger         action.DebugLog
+	namespace      string
+	disabledAddons map[string]bool
 }
 
 func (c *Custom) Version() (map[string]string, error) {
@@ -71,6 +73,10 @@ func (c *Custom) applyOne(ctx context.Context, ochart hembed.HelmChart) error {
 	if err != nil {
 		return fmt.Errorf("unable to load chart archive: %w", err)
 	}
+	if c.chartHasBeenDisabled(chart) {
+		c.logger("Skipping disabled chart %s", chart.Name())
+		return nil
+	}
 	var values map[string]interface{}
 	if len(ochart.Values) > 0 {
 		values = make(map[string]interface{})
@@ -79,6 +85,12 @@ func (c *Custom) applyOne(ctx context.Context, ochart hembed.HelmChart) error {
 		}
 	}
 	return c.applyChart(ctx, chart, values)
+}
+
+func (c *Custom) chartHasBeenDisabled(chart *chart.Chart) bool {
+	cname := strings.ToLower(chart.Name())
+	_, disabledAddons := c.disabledAddons[cname]
+	return disabledAddons
 }
 
 func (c *Custom) applyChart(ctx context.Context, chart *chart.Chart, values map[string]interface{}) error {
@@ -125,12 +137,17 @@ func (c *Custom) installedRelease(name string) (*release.Release, error) {
 	return releases[0], nil
 }
 
-func New(namespace string, logger action.DebugLog) (*Custom, error) {
+func New(namespace string, logger action.DebugLog, disabledAddons map[string]bool) (*Custom, error) {
 	env := cli.New()
 	env.SetNamespace(namespace)
 	config := &action.Configuration{}
 	if err := config.Init(env.RESTClientGetter(), namespace, "", logger); err != nil {
 		return nil, fmt.Errorf("unable to init configuration: %w", err)
 	}
-	return &Custom{namespace: namespace, config: config, logger: logger}, nil
+	return &Custom{
+		namespace:      namespace,
+		config:         config,
+		logger:         logger,
+		disabledAddons: disabledAddons,
+	}, nil
 }

--- a/pkg/addons/options.go
+++ b/pkg/addons/options.go
@@ -1,0 +1,28 @@
+package addons
+
+import "strings"
+
+// Option sets and option on an Applier reference.
+type Option func(*Applier)
+
+// WithoutAddon disables an addon from being applied.
+func WithoutAddon(addon string) Option {
+	addon = strings.ToLower(addon)
+	return func(a *Applier) {
+		a.disabledAddons[addon] = true
+	}
+}
+
+// WithoutPrompt disables the prompt before applying addons.
+func WithoutPrompt() Option {
+	return func(a *Applier) {
+		a.prompt = false
+	}
+}
+
+// Quiet disables logging for addons.
+func Quiet() Option {
+	return func(a *Applier) {
+		a.verbose = false
+	}
+}

--- a/pkg/hembed/hembed.go
+++ b/pkg/hembed/hembed.go
@@ -1,6 +1,6 @@
 // Package hembed manages the helm chart embedding mechanism. It is used when the user
 // wants to embed a custom helm chart into the helmvm binary. Writes the chart and adds
-// a mark to the end of the file. The mark is on the format ANKORCHARTS0000000000 where
+// a mark to the end of the file. The mark is on the format HELMVMCHARTS0000000000 where
 // the number is the length of the embedded data.
 package hembed
 
@@ -21,7 +21,7 @@ import (
 
 const (
 	BaseDir = "/helmvm"
-	EndMark = "ANKORCHARTS"
+	EndMark = "HELMVMCHARTS"
 )
 
 // Binary is a helpes struct that holds a closer and a reader separately. Reads happen
@@ -112,7 +112,7 @@ func CalculateRewind(fpath string) (int64, int64, error) {
 // ReadEmbeddedData reads the embedded data from the binary. It reads the binary from
 // the disk and looks for a mark at the end of the file. If the mark is found, it reads
 // the data that is embedded in the binary and returns it. The mark is on the format
-// ANKORCHARTS0000000000 where the number is the length of the embedded data.
+// HELMVMCHARTS0000000000 where the number is the length of the embedded data.
 func ReadEmbeddedData(fpath string) ([]byte, error) {
 	fp, err := os.Open(fpath)
 	if err != nil {


### PR DESCRIPTION
to prepare helmvm for kots regression testing we need to give users the ability to deactivate add-on installations. this feature will enable kots to bypass the add-on installation during regression tests. they can then install their current development branch over a clean helmvm setup to conduct their tests.