### PR TITLE
feat: replace warn calls with print

### DIFF
--- a/cmd/helmvm/install.go
+++ b/cmd/helmvm/install.go
@@ -87,7 +87,7 @@ func runHostPreflights(c *cli.Context) error {
 	if !outputs.HaveWarns() || c.Bool("no-prompt") {
 		return nil
 	}
-	logrus.Warn("Host preflights have warnings on one or more hosts")
+	fmt.Println("Host preflights have warnings on one or more hosts")
 	if !prompts.New().Confirm("Do you want to continue ?", false) {
 		return fmt.Errorf("user aborted")
 	}
@@ -196,10 +196,10 @@ func copyUserProvidedConfig(c *cli.Context) error {
 // overwriteExistingConfig asks user if they want to overwrite the existing cluster
 // configuration file.
 func overwriteExistingConfig() bool {
-	logrus.Warn("A cluster configuration file was found. This means you already")
-	logrus.Warn("have created and configured a cluster. You can either use the")
-	logrus.Warn("existing configuration or create a new one (the original config")
-	logrus.Warn("will be backed up).")
+	fmt.Println("A cluster configuration file was found. This means you already")
+	fmt.Println("have created and configured a cluster. You can either use the")
+	fmt.Println("existing configuration or create a new one (the original config")
+	fmt.Println("will be backed up).")
 	return prompts.New().Confirm(
 		"Do you want to create a new cluster configuration ?", false,
 	)
@@ -381,9 +381,9 @@ var installCommand = &cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		if defaults.DecentralizedInstall() {
-			logrus.Warnf("Decentralized install was detected. To manage the cluster")
-			logrus.Warnf("you have to use the '%s node' commands instead.", defaults.BinaryName())
-			logrus.Warnf("Run '%s node --help' for more information.", defaults.BinaryName())
+			fmt.Println("Decentralized install was detected. To manage the cluster")
+			fmt.Printf("you have to use the '%s node' commands instead.\n", defaults.BinaryName())
+			fmt.Printf("Run '%s node --help' for more information.\n", defaults.BinaryName())
 			return fmt.Errorf("decentralized install detected")
 		}
 		useprompt := !c.Bool("no-prompt")

--- a/cmd/helmvm/token.go
+++ b/cmd/helmvm/token.go
@@ -65,10 +65,10 @@ var tokenCreateCommand = &cli.Command{
 		}
 		logrus.Infof("Creating node join token for role %s", role)
 		if !defaults.DecentralizedInstall() {
-			logrus.Warn("You are opting out of the centralized cluster management.")
-			logrus.Warn("Through the centralized management you can manage all your")
-			logrus.Warn("cluster nodes from a single location. If you decide to move")
-			logrus.Warn("on the centralized management won't be available anymore")
+			fmt.Println("You are opting out of the centralized cluster management.")
+			fmt.Println("Through the centralized management you can manage all your")
+			fmt.Println("cluster nodes from a single location. If you decide to move")
+			fmt.Println("on the centralized management won't be available anymore")
 			if useprompt && !prompts.New().Confirm("Do you want to continue ?", true) {
 				return nil
 			}

--- a/cmd/helmvm/upgrade.go
+++ b/cmd/helmvm/upgrade.go
@@ -81,7 +81,7 @@ func runHostPreflightsLocally(c *cli.Context) error {
 	if !out.HasWarn() || c.Bool("no-prompt") {
 		return nil
 	}
-	logrus.Warn("Host preflights have warnings on one or more hosts")
+	fmt.Println("Host preflights have warnings on one or more hosts")
 	if !prompts.New().Confirm("Do you want to continue ?", false) {
 		return fmt.Errorf("user aborted")
 	}

--- a/pkg/addons/adminconsole/adminconsole.go
+++ b/pkg/addons/adminconsole/adminconsole.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/mod/semver"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -43,7 +42,7 @@ type AdminConsole struct {
 
 func (a *AdminConsole) askPassword() (string, error) {
 	if !a.useprompt {
-		logrus.Warnf("Admin Console password set to: password")
+		fmt.Println("Admin Console password set to: password")
 		return "password", nil
 	}
 	return prompts.New().Password("Enter a new Admin Console password:"), nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -109,7 +109,7 @@ func askUserForHostConfig(keys []string, host *hostcfg) error {
 	for port == 0 {
 		str := quiz.Input("SSH port:", strconv.Itoa(host.Port), true)
 		if port, err = strconv.Atoi(str); err != nil {
-			logrus.Warnf("Invalid port number")
+			fmt.Println("Invalid port number")
 		}
 	}
 	host.Port = port
@@ -133,8 +133,8 @@ func collectHostConfig(host hostcfg) (*cluster.Host, error) {
 		}
 		logrus.Infof("Testing SSH connection to %s", host.Address)
 		if err := host.testConnection(); err != nil {
-			logrus.Warnf("Unable to connect to %s", host.Address)
-			logrus.Warnf("Please check the provided SSH configuration.")
+			fmt.Printf("Unable to connect to %s\n", host.Address)
+			fmt.Println("Please check the provided SSH configuration.")
 			continue
 		}
 		logrus.Infof("SSH connection to %s successful", host.Address)

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/jedib0t/go-pretty/table"
-	"github.com/sirupsen/logrus"
 
 	"github.com/replicatedhq/helmvm/pkg/defaults"
 	pb "github.com/replicatedhq/helmvm/pkg/progressbar"
@@ -56,7 +55,7 @@ func Apply(ctx context.Context, dir string, useprompt bool) ([]Node, error) {
 // printNodes prints the nodes to stdout in a table.
 func printNodes(nodes []Node) {
 	if len(nodes) == 0 {
-		logrus.Warnf("No node found in terraform output")
+		fmt.Println("No node found in terraform output")
 		return
 	}
 	fmt.Println("These are the nodes configuration applied by your configuration:")


### PR DESCRIPTION
it is weird to have logrus warn messages being printed during the installs. this pr replaces them with fmt.print calls.