### PR TITLE
chore: setting the specific version in go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.6-bullseye AS builder
+FROM golang:1.21.0-bullseye AS builder
 RUN apt update -y
 RUN apt install -y unzip
 WORKDIR /helmvm-builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicatedhq/helmvm
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6


### PR DESCRIPTION
since go 1.21 we need to specify also the minor go version: https://github.com/golang/go/issues/62278

without it dependabot is failing with:

```
Dependabot encountered the following error:
go: downloading go1.21 (linux/amd64)
go: download go1.21 for linux/amd64: toolchain not available
```