### PR TITLE
chore: bump go version on release actions

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: Build linux-amd64
         run: |
           make helmvm-linux-amd64

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: Build linux-amd64
         run: |
           make helmvm-linux-amd64 VERSION=$TAG_NAME


### PR DESCRIPTION
bump go to 1.21 on github release actions.