### PR TITLE
feat: stop forcing installs and upload binary

### DIFF
--- a/cmd/helmvm/install.go
+++ b/cmd/helmvm/install.go
@@ -239,6 +239,9 @@ func ensureK0sctlConfig(c *cli.Context, nodes []infra.Node, useprompt bool) erro
 	if err != nil {
 		return fmt.Errorf("unable to render config: %w", err)
 	}
+	if bundledir != "" {
+		config.SetUploadBinary(cfg)
+	}
 	if err := config.UpdateHostsFiles(cfg, bundledir); err != nil {
 		return fmt.Errorf("unable to update hosts files: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,13 @@ func ReadConfigFile(cfgPath string) (*v1beta1.Cluster, error) {
 	return &cfg, nil
 }
 
+// SetUploadBinary sets the upload binary config to true in all hosts in the provided configuration.
+func SetUploadBinary(config *v1beta1.Cluster) {
+	for i := range config.Spec.Hosts {
+		config.Spec.Hosts[i].UploadBinary = true
+	}
+}
+
 // RenderClusterConfig renders a cluster configuration interactively.
 func RenderClusterConfig(ctx context.Context, nodes []infra.Node, multi bool) (*v1beta1.Cluster, error) {
 	if multi {

--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -23,13 +23,13 @@ type hostcfg struct {
 
 // render returns a cluster.Host from the given config.
 func (h *hostcfg) render() *cluster.Host {
-	ifls := []string{"--force", "--disable-components konnectivity-server"}
-	if h.Role == "worker" {
-		ifls = []string{"--force"}
+	var ifls []string
+	if h.Role != "worker" {
+		ifls = []string{"--disable-components konnectivity-server"}
 	}
 	return &cluster.Host{
 		Role:         h.Role,
-		UploadBinary: true,
+		UploadBinary: false,
 		NoTaints:     h.Role == "controller+worker",
 		InstallFlags: ifls,
 		Connection: rig.Connection{


### PR DESCRIPTION
this commit makes upload binary option to be true only in air gap environments and removes a --force flag reminiscent from a test.