### PR TITLE
feat: including support-bundle binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ K0SCTL_VERSION = v0.15.5
 TERRAFORM_VERSION = 1.5.4
 OPENEBS_VERSION = 3.7.0
 K0S_VERSION = v1.27.5+k0s.0
-PREFLIGHT_VERSION = v0.71.1
+TROUBLESHOOT_VERSION = v0.72.0
 LD_FLAGS = -X github.com/replicatedhq/helmvm/pkg/defaults.K0sVersion=$(K0S_VERSION) -X main.Version=$(VERSION)
 
 default: helmvm-linux-amd64
@@ -95,28 +95,49 @@ pkg/goods/bins/helmvm/k0sctl-darwin-arm64:
 	curl -L -o pkg/goods/bins/helmvm/k0sctl-darwin-arm64 "https://github.com/k0sproject/k0sctl/releases/download/$(K0SCTL_VERSION)/k0sctl-darwin-arm64"
 	chmod +x pkg/goods/bins/helmvm/k0sctl-darwin-arm64
 
-pkg/goods/bins/helmvm/preflight:
+pkg/goods/bins/helmvm/kubectl-support_bundle-linux-amd64:
+	mkdir -p pkg/goods/bins/helmvm
+	mkdir -p output/tmp/support-bundle
+	curl -L -o output/tmp/support-bundle/support-bundle.tar.gz https://github.com/replicatedhq/troubleshoot/releases/download/$(TROUBLESHOOT_VERSION)/support-bundle_linux_amd64.tar.gz
+	tar -xzf output/tmp/support-bundle/support-bundle.tar.gz -C output/tmp/support-bundle
+	mv output/tmp/support-bundle/support-bundle pkg/goods/bins/helmvm/kubectl-support_bundle-linux-amd64
+
+pkg/goods/bins/helmvm/kubectl-support_bundle-darwin-amd64:
+	mkdir -p pkg/goods/bins/helmvm
+	mkdir -p output/tmp/support-bundle
+	curl -L -o output/tmp/support-bundle/support-bundle.tar.gz https://github.com/replicatedhq/troubleshoot/releases/download/$(TROUBLESHOOT_VERSION)/support-bundle_darwin_amd64.tar.gz
+	tar -xzf output/tmp/support-bundle/support-bundle.tar.gz -C output/tmp/support-bundle
+	mv output/tmp/support-bundle/support-bundle pkg/goods/bins/helmvm/kubectl-support_bundle-darwin-amd64
+
+pkg/goods/bins/helmvm/kubectl-support_bundle-darwin-arm64:
+	mkdir -p pkg/goods/bins/helmvm
+	mkdir -p output/tmp/support-bundle
+	curl -L -o output/tmp/support-bundle/support-bundle.tar.gz https://github.com/replicatedhq/troubleshoot/releases/download/$(TROUBLESHOOT_VERSION)/support-bundle_darwin_arm64.tar.gz
+	tar -xzf output/tmp/support-bundle/support-bundle.tar.gz -C output/tmp/support-bundle
+	mv output/tmp/support-bundle/support-bundle pkg/goods/bins/helmvm/kubectl-support_bundle-darwin-arm64
+
+pkg/goods/bins/helmvm/kubectl-preflight:
 	mkdir -p pkg/goods/bins/helmvm
 	mkdir -p output/tmp/preflight
-	curl -L -o output/tmp/preflight/preflight.tar.gz https://github.com/replicatedhq/troubleshoot/releases/download/$(PREFLIGHT_VERSION)/preflight_linux_amd64.tar.gz
+	curl -L -o output/tmp/preflight/preflight.tar.gz https://github.com/replicatedhq/troubleshoot/releases/download/$(TROUBLESHOOT_VERSION)/preflight_linux_amd64.tar.gz
 	tar -xzf output/tmp/preflight/preflight.tar.gz -C output/tmp/preflight
-	mv output/tmp/preflight/preflight pkg/goods/bins/helmvm/preflight
+	mv output/tmp/preflight/preflight pkg/goods/bins/helmvm/kubectl-preflight
 
 .PHONY: static
 static: pkg/addons/adminconsole/charts/adminconsole-$(ADMIN_CONSOLE_CHART_VERSION).tgz \
 	output/bin/yq \
-	pkg/goods/bins/helmvm/preflight \
+	pkg/goods/bins/helmvm/kubectl-preflight \
 	pkg/goods/bins/k0sctl/k0s-$(K0S_VERSION) \
 	pkg/goods/images/list.txt
 
 .PHONY: static-darwin-arm64
-static-darwin-arm64: pkg/goods/bins/helmvm/kubectl-darwin-arm64 pkg/goods/bins/helmvm/k0sctl-darwin-arm64 pkg/goods/bins/helmvm/terraform-darwin-arm64
+static-darwin-arm64: pkg/goods/bins/helmvm/kubectl-darwin-arm64 pkg/goods/bins/helmvm/k0sctl-darwin-arm64 pkg/goods/bins/helmvm/terraform-darwin-arm64 pkg/goods/bins/helmvm/kubectl-support_bundle-darwin-arm64
 
 .PHONY: static-darwin-amd64
-static-darwin-amd64: pkg/goods/bins/helmvm/kubectl-darwin-amd64 pkg/goods/bins/helmvm/k0sctl-darwin-amd64 pkg/goods/bins/helmvm/terraform-darwin-amd64
+static-darwin-amd64: pkg/goods/bins/helmvm/kubectl-darwin-amd64 pkg/goods/bins/helmvm/k0sctl-darwin-amd64 pkg/goods/bins/helmvm/terraform-darwin-amd64 pkg/goods/bins/helmvm/kubectl-support_bundle-darwin-amd64
 
 .PHONY: static-linux-amd64
-static-linux-amd64: pkg/goods/bins/helmvm/kubectl-linux-amd64 pkg/goods/bins/helmvm/k0sctl-linux-amd64 pkg/goods/bins/helmvm/terraform-linux-amd64
+static-linux-amd64: pkg/goods/bins/helmvm/kubectl-linux-amd64 pkg/goods/bins/helmvm/k0sctl-linux-amd64 pkg/goods/bins/helmvm/terraform-linux-amd64 pkg/goods/bins/helmvm/kubectl-support_bundle-linux-amd64
 
 .PHONY: helmvm-linux-amd64
 helmvm-linux-amd64: static static-linux-amd64

--- a/pkg/goods/goods.go
+++ b/pkg/goods/goods.go
@@ -50,9 +50,9 @@ func Materialize() error {
 	suffix := fmt.Sprintf("-%s-%s", runtime.GOOS, runtime.GOARCH)
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), suffix) {
-			// we always materialize 'preflight' binary because
+			// we always materialize 'kubectl-preflight' binary because
 			// we run it remotely in the configured cluster nodes.
-			if entry.Name() != "preflight" {
+			if entry.Name() != "kubectl-preflight" {
 				continue
 			}
 		}


### PR DESCRIPTION
we are including support-bundle binary from now on. this commit also renames the `preflight` binary to `kubectl-preflight` so it properly behaves as a kubectl plugin (same for support-bundle binary).