### PR TITLE
feat: stop providing "controller" as a valid node role

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,7 +26,7 @@ import (
 )
 
 // roles holds a list of valid roles.
-var roles = []string{"controller+worker", "controller", "worker"}
+var roles = []string{"controller+worker", "worker"}
 
 // quiz prompts for the cluster configuration interactively.
 var quiz = prompts.New()


### PR DESCRIPTION
we have decided to remove the "controller" role from the configuration step. we only allow roles "worker" and "controller+worker".