### PR TITLE
chore: fix end to end tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,6 +37,7 @@ jobs:
         sudo lxd waitready
     - name: Install and configure OVN
       run: |
+        sudo apt update -y
         sudo apt install ovn-host ovn-central -y
         sudo ovs-vsctl set open_vswitch .                            \
              external_ids:ovn-remote=unix:/var/run/ovn/ovnsb_db.sock \

--- a/e2e/embed_test.go
+++ b/e2e/embed_test.go
@@ -18,12 +18,15 @@ func TestEmbedAndInstall(t *testing.T) {
 	})
 	defer tc.Destroy()
 	t.Log("installing ssh in node 0")
-	line := []string{"apt", "install", "openssh-server", "-y"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+	commands := [][]string{
+		{"apt", "update", "-y"},
+		{"apt", "install", "openssh-server", "-y"},
+	}
+	if err := RunCommandsOnNode(t, tc, 0, commands); err != nil {
 		t.Fatalf("fail to install ssh on node %s: %v", tc.Nodes[0], err)
 	}
 	t.Log("pulling helm chart, embedding, and installing on node 0")
-	line = []string{"embed-and-install.sh"}
+	line := []string{"embed-and-install.sh"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install embedded ssh in node 0: %v", err)
 	}
@@ -41,12 +44,15 @@ func TestEmbedAddonsOnly(t *testing.T) {
 	})
 	defer tc.Destroy()
 	t.Log("installing ssh in node 0")
-	line := []string{"apt", "install", "openssh-server", "-y"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+	commands := [][]string{
+		{"apt", "update", "-y"},
+		{"apt", "install", "openssh-server", "-y"},
+	}
+	if err := RunCommandsOnNode(t, tc, 0, commands); err != nil {
 		t.Fatalf("fail to install ssh on node %s: %v", tc.Nodes[0], err)
 	}
 	t.Log("installing helmvm on node 0")
-	line = []string{"single-node-install.sh"}
+	line := []string{"single-node-install.sh"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install helmvm on node %s: %v", tc.Nodes[0], err)
 	}

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -20,12 +20,15 @@ func TestTokenBasedMultiNodeInstallation(t *testing.T) {
 	})
 	defer tc.Destroy()
 	t.Log("installing ssh on node 0")
-	line := []string{"apt", "install", "openssh-server", "-y"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+	commands := [][]string{
+		{"apt", "update", "-y"},
+		{"apt", "install", "openssh-server", "-y"},
+	}
+	if err := RunCommandsOnNode(t, tc, 0, commands); err != nil {
 		t.Fatalf("fail to install ssh on node %s: %v", tc.Nodes[0], err)
 	}
 	t.Log("installing helmvm on node 0")
-	line = []string{"single-node-install.sh"}
+	line := []string{"single-node-install.sh"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install helmvm on node %s: %v", tc.Nodes[0], err)
 	}
@@ -78,12 +81,15 @@ func TestSingleNodeInstallation(t *testing.T) {
 	})
 	defer tc.Destroy()
 	t.Log("installing ssh on node 0")
-	line := []string{"apt", "install", "openssh-server", "-y"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+	commands := [][]string{
+		{"apt", "update", "-y"},
+		{"apt", "install", "openssh-server", "-y"},
+	}
+	if err := RunCommandsOnNode(t, tc, 0, commands); err != nil {
 		t.Fatalf("fail to install ssh on node %s: %v", tc.Nodes[0], err)
 	}
 	t.Log("installing helmvm on node 0")
-	line = []string{"single-node-install.sh"}
+	line := []string{"single-node-install.sh"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install helmvm on node %s: %v", tc.Nodes[0], err)
 	}
@@ -103,8 +109,11 @@ func TestMultiNodeInstallation(t *testing.T) {
 	defer tc.Destroy()
 	for i := range tc.Nodes {
 		t.Logf("installing ssh on node %d", i)
-		line := []string{"apt", "install", "openssh-server", "-y"}
-		if _, _, err := RunCommandOnNode(t, tc, i, line); err != nil {
+		commands := [][]string{
+			{"apt", "update", "-y"},
+			{"apt", "install", "openssh-server", "-y"},
+		}
+		if err := RunCommandsOnNode(t, tc, i, commands); err != nil {
 			t.Fatalf("fail to install ssh on node %d: %v", i, err)
 		}
 	}
@@ -154,12 +163,15 @@ func TestSingleNodeInstallationDebian12(t *testing.T) {
 	})
 	defer tc.Destroy()
 	t.Log("installing ssh on node 0")
-	line := []string{"apt", "install", "openssh-server", "-y"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+	commands := [][]string{
+		{"apt", "update", "-y"},
+		{"apt", "install", "openssh-server", "-y"},
+	}
+	if err := RunCommandsOnNode(t, tc, 0, commands); err != nil {
 		t.Fatalf("fail to install ssh on node 0: %v", err)
 	}
 	t.Log("installing helmvm on node 0")
-	line = []string{"single-node-install.sh"}
+	line := []string{"single-node-install.sh"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install helmvm on node %s: %v", tc.Nodes[0], err)
 	}
@@ -207,8 +219,11 @@ func TestMultiNodeInteractiveInstallation(t *testing.T) {
 	defer tc.Destroy()
 	for i := range tc.Nodes {
 		t.Logf("installing ssh on node %d", i)
-		line := []string{"apt", "install", "openssh-server", "-y"}
-		if _, _, err := RunCommandOnNode(t, tc, i, line); err != nil {
+		commands := [][]string{
+			{"apt", "update", "-y"},
+			{"apt", "install", "openssh-server", "-y"},
+		}
+		if err := RunCommandsOnNode(t, tc, i, commands); err != nil {
 			t.Fatalf("fail to install ssh on node %d: %v", i, err)
 		}
 	}
@@ -241,12 +256,15 @@ func TestInstallWithDisabledAddons(t *testing.T) {
 	})
 	defer tc.Destroy()
 	t.Log("installing ssh in node 0")
-	line := []string{"apt", "install", "openssh-server", "-y"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
+	commands := [][]string{
+		{"apt", "update", "-y"},
+		{"apt", "install", "openssh-server", "-y"},
+	}
+	if err := RunCommandsOnNode(t, tc, 0, commands); err != nil {
 		t.Fatalf("fail to install ssh on node %s: %v", tc.Nodes[0], err)
 	}
 	t.Log("installling with disabled addons on node 0")
-	line = []string{"install-with-disabled-addons.sh"}
+	line := []string{"install-with-disabled-addons.sh"}
 	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
 		t.Fatalf("fail to install embedded ssh in node 0: %v", err)
 	}

--- a/e2e/scripts/addons-only.sh
+++ b/e2e/scripts/addons-only.sh
@@ -37,7 +37,10 @@ install_helm() {
 
 pull_helm_chart() {
     mkdir chart
-    if ! helm pull oci://registry-1.docker.io/bitnamicharts/memcached --destination chart; then
+    if ! helm repo add bitnami https://charts.bitnami.com/bitnami ; then
+        return 1
+    fi
+    if ! helm pull bitnami/memcached --version 6.6.2 --destination chart; then
         return 1
     fi
     return 0

--- a/e2e/scripts/embed-and-install.sh
+++ b/e2e/scripts/embed-and-install.sh
@@ -37,7 +37,10 @@ install_helm() {
 
 pull_helm_chart() {
     mkdir chart
-    if ! helm pull oci://registry-1.docker.io/bitnamicharts/memcached --destination chart; then
+    if ! helm repo add bitnami https://charts.bitnami.com/bitnami ; then
+        return 1
+    fi
+    if ! helm pull bitnami/memcached --version 6.6.2 --destination chart; then
         return 1
     fi
     return 0

--- a/e2e/scripts/install-with-disabled-addons.sh
+++ b/e2e/scripts/install-with-disabled-addons.sh
@@ -34,7 +34,10 @@ install_helm() {
 
 pull_helm_chart() {
     mkdir chart
-    if ! helm pull oci://registry-1.docker.io/bitnamicharts/memcached --destination chart; then
+    if ! helm repo add bitnami https://charts.bitnami.com/bitnami ; then
+        return 1
+    fi
+    if ! helm pull bitnami/memcached --version 6.6.2 --destination chart; then
         return 1
     fi
     return 0


### PR DESCRIPTION
we were not running `apt update` before attempting to install packages and we need to change the way we pull the memcached helmchart (https://github.com/bitnami/charts/issues/19599).