### PR TITLE
Revert "go.mod versions cannot specify the patch, only minor"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicatedhq/helmvm
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Reverts replicatedhq/helmvm#96

Apparently this has changed in go 1.21