### PR TITLE
feat: allow users to provide an embedded cluster config path

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,14 +68,14 @@ func RenderClusterConfig(ctx context.Context, multi bool) (*v1beta1.Cluster, err
 		if err != nil {
 			return nil, fmt.Errorf("unable to render multi-node config: %w", err)
 		}
-		applyEmbeddedUnsupportedOverrides(cfg, embconfig)
+		ApplyEmbeddedUnsupportedOverrides(cfg, embconfig)
 		return cfg, nil
 	}
 	cfg, err := renderSingleNodeConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to render single-node config: %w", err)
 	}
-	applyEmbeddedUnsupportedOverrides(cfg, embconfig)
+	ApplyEmbeddedUnsupportedOverrides(cfg, embconfig)
 	return renderSingleNodeConfig(ctx)
 }
 
@@ -373,8 +373,8 @@ type UnsupportedConfigOverrides struct {
 	} `yaml:"spec"`
 }
 
-// applyEmbeddedUnsupportedOverrides applies the custom configuration to the cluster config.
-func applyEmbeddedUnsupportedOverrides(config *v1beta1.Cluster, embconfig []byte) error {
+// ApplyEmbeddedUnsupportedOverrides applies the custom configuration to the cluster config.
+func ApplyEmbeddedUnsupportedOverrides(config *v1beta1.Cluster, embconfig []byte) error {
 	if embconfig == nil {
 		return nil
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,7 +14,7 @@ import (
 //go:embed testdata/*yaml
 var testData embed.FS
 
-func Test_applyUnsupportedOverrides(t *testing.T) {
+func TestApplyUnsupportedOverrides(t *testing.T) {
 	type test struct {
 		Name     string
 		Config   string `yaml:"config"`
@@ -42,7 +42,7 @@ func Test_applyUnsupportedOverrides(t *testing.T) {
 			var config v1beta1.Cluster
 			err := yaml.Unmarshal([]byte(tt.Config), &config)
 			assert.NoError(t, err)
-			err = applyEmbeddedUnsupportedOverrides(&config, []byte(tt.Override))
+			err = ApplyEmbeddedUnsupportedOverrides(&config, []byte(tt.Override))
 			assert.NoError(t, err)
 			result, err := yaml.Marshal(config)
 			assert.NoError(t, err)


### PR DESCRIPTION
allow users to provide through the --overrides flag a path to a file containing an embedded cluster configuration object. the file is then read and its unsupported overrides are used to overrides the generated config.