### PR TITLE
feat: using short token instead of k0s token

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,7 +11,6 @@ jobs:
         - TestEmbedAndInstall
         - TestMultiNodeInstallation
         - TestSingleNodeInstallation
-        - TestTokenBasedMultiNodeInstallation
         - TestSingleNodeInstallationRockyLinux8
         - TestSingleNodeInstallationDebian12
         - TestSingleNodeInstallationCentos8Stream

--- a/cmd/helmvm/join.go
+++ b/cmd/helmvm/join.go
@@ -34,7 +34,7 @@ type JoinCommandResponse struct {
 // getJoinToken issues a request to the kots api to get the actual join command
 // based on the short token provided by the user.
 func getJoinToken(ctx context.Context, baseURL, shortToken string) (*JoinCommandResponse, error) {
-	url := fmt.Sprintf("%s/helmvm/join?token=%s", baseURL, shortToken)
+	url := fmt.Sprintf("%s/api/v1/embedded-cluster/join?token=%s", baseURL, shortToken)
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -1,73 +1,10 @@
 package e2e
 
 import (
-	"bufio"
-	"strings"
 	"testing"
 
 	"github.com/replicatedhq/helmvm/e2e/cluster"
 )
-
-func TestTokenBasedMultiNodeInstallation(t *testing.T) {
-	t.Parallel()
-	tc := cluster.NewTestCluster(&cluster.Input{
-		T:             t,
-		Nodes:         3,
-		Image:         "ubuntu/jammy",
-		SSHPublicKey:  "../output/tmp/id_rsa.pub",
-		SSHPrivateKey: "../output/tmp/id_rsa",
-		HelmVMPath:    "../output/bin/helmvm",
-	})
-	defer tc.Destroy()
-	t.Log("installing ssh on node 0")
-	commands := [][]string{
-		{"apt-get", "update", "-y"},
-		{"apt-get", "install", "openssh-server", "-y"},
-	}
-	if err := RunCommandsOnNode(t, tc, 0, commands); err != nil {
-		t.Fatalf("fail to install ssh on node %s: %v", tc.Nodes[0], err)
-	}
-	t.Log("installing helmvm on node 0")
-	line := []string{"single-node-install.sh"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
-		t.Fatalf("fail to install helmvm on node %s: %v", tc.Nodes[0], err)
-	}
-	t.Log("generating token on node 0")
-	line = []string{"helmvm", "node", "token", "create", "--role", "controller", "--no-prompt"}
-	stdout, _, err := RunCommandOnNode(t, tc, 0, line)
-	if err != nil {
-		t.Fatalf("fail to generate token on node %s: %v", tc.Nodes[0], err)
-
-	}
-
-	var joinCommand []string
-
-	// scan stdout for our command that starts with `helmvm`
-	newScanner := bufio.NewScanner(strings.NewReader(stdout))
-	for newScanner.Scan() {
-		line := newScanner.Text()
-		if strings.HasPrefix(line, "helmvm") {
-			joinCommand = strings.Split(line, " ")
-			break
-		}
-	}
-
-	if joinCommand == nil {
-		t.Fatalf("could not find token in stdout")
-	}
-
-	for i := 1; i <= 2; i++ {
-		t.Logf("joining node %d to the cluster", i)
-		if _, _, err := RunCommandOnNode(t, tc, i, joinCommand); err != nil {
-			t.Fatalf("fail to join node %d: %v", i, err)
-		}
-	}
-	t.Log("waiting for cluster nodes to report ready")
-	line = []string{"wait-for-ready-nodes.sh", "3"}
-	if _, _, err := RunCommandOnNode(t, tc, 0, line); err != nil {
-		t.Fatalf("nodes not reporting ready: %v", err)
-	}
-}
 
 func TestSingleNodeInstallation(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
short tokens are easier and better looking, this pr introduces them into the regular node join workflow.

we do a request to kotsadm passing in the short token and receive back the actual token + some other information, we then write down the token and run the k0s install command.